### PR TITLE
fix: rendre toutes les migrations idempotentes

### DIFF
--- a/supabase/migrations/20250819000000_auth_refactor.sql
+++ b/supabase/migrations/20250819000000_auth_refactor.sql
@@ -222,11 +222,13 @@ $$ LANGUAGE plpgsql SECURITY DEFINER;
 
 -- 10. TRIGGERS POUR METTRE À JOUR updated_at
 -- ============================================
+DROP TRIGGER IF EXISTS update_members_updated_at ON public.members;
 CREATE TRIGGER update_members_updated_at
   BEFORE UPDATE ON public.members
   FOR EACH ROW
   EXECUTE FUNCTION update_updated_at_column();
 
+DROP TRIGGER IF EXISTS update_groups_updated_at ON public.groups;
 CREATE TRIGGER update_groups_updated_at
   BEFORE UPDATE ON public.groups
   FOR EACH ROW

--- a/supabase/migrations/20250819201300_fix_auth_trigger.sql
+++ b/supabase/migrations/20250819201300_fix_auth_trigger.sql
@@ -75,6 +75,7 @@ END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 
 -- 3. Recréer le trigger
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
 CREATE TRIGGER on_auth_user_created
   AFTER INSERT ON auth.users
   FOR EACH ROW 

--- a/supabase/migrations/20250819204500_final_auth_fix.sql
+++ b/supabase/migrations/20250819204500_final_auth_fix.sql
@@ -100,6 +100,7 @@ END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 
 -- 6. Recréer le trigger
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
 CREATE TRIGGER on_auth_user_created
   AFTER INSERT ON auth.users
   FOR EACH ROW 

--- a/supabase/migrations/20250821090000_add_donations_system.sql
+++ b/supabase/migrations/20250821090000_add_donations_system.sql
@@ -62,7 +62,7 @@ CREATE TABLE IF NOT EXISTS app_settings_donation (
 );
 
 -- Index pour le tri
-CREATE INDEX idx_app_settings_donation_order ON app_settings_donation(display_order, amount);
+CREATE INDEX IF NOT EXISTS idx_app_settings_donation_order ON app_settings_donation(display_order, amount);
 
 -- Insérer les exemples de dons par défaut
 INSERT INTO app_settings_donation (amount, title, description, display_order) VALUES
@@ -215,15 +215,19 @@ END;
 $$ LANGUAGE plpgsql;
 
 -- Appliquer le trigger aux nouvelles tables
+DROP TRIGGER IF EXISTS update_donations_updated_at ON donations;
 CREATE TRIGGER update_donations_updated_at BEFORE UPDATE ON donations
   FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
+DROP TRIGGER IF EXISTS update_app_settings_updated_at ON app_settings;
 CREATE TRIGGER update_app_settings_updated_at BEFORE UPDATE ON app_settings
   FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
+DROP TRIGGER IF EXISTS update_app_settings_donation_updated_at ON app_settings_donation;
 CREATE TRIGGER update_app_settings_donation_updated_at BEFORE UPDATE ON app_settings_donation
   FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
+DROP TRIGGER IF EXISTS update_checkout_sessions_updated_at ON checkout_sessions;
 CREATE TRIGGER update_checkout_sessions_updated_at BEFORE UPDATE ON checkout_sessions
   FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 

--- a/supabase/migrations/20250822090000_add_slack_integration.sql
+++ b/supabase/migrations/20250822090000_add_slack_integration.sql
@@ -231,6 +231,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS update_slack_app_config_updated_at ON slack_app_config;
 CREATE TRIGGER update_slack_app_config_updated_at
   BEFORE UPDATE ON slack_app_config
   FOR EACH ROW

--- a/supabase/migrations/20250823100000_sync_user_avatars.sql
+++ b/supabase/migrations/20250823100000_sync_user_avatars.sql
@@ -55,6 +55,7 @@ END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 
 -- 5. Créer le trigger pour synchroniser les avatars
+DROP TRIGGER IF EXISTS sync_avatar_on_member_update ON public.members;
 CREATE TRIGGER sync_avatar_on_member_update
   AFTER UPDATE OF photo_url ON public.members
   FOR EACH ROW


### PR DESCRIPTION
- Ajout de DROP TRIGGER IF EXISTS avant tous les CREATE TRIGGER
- Ajout de IF NOT EXISTS à tous les CREATE INDEX
- Assure que les migrations peuvent être exécutées plusieurs fois sans erreur
- Corrige les problèmes de déploiement en production

🤖 Generated with [Claude Code](https://claude.ai/code)