### PR TITLE
fix: rendre TOUTES les migrations complètement idempotentes

### DIFF
--- a/supabase/migrations/20250819000000_auth_refactor.sql
+++ b/supabase/migrations/20250819000000_auth_refactor.sql
@@ -240,6 +240,10 @@ CREATE TRIGGER update_groups_updated_at
 -- RLS pour la table groups
 ALTER TABLE public.groups ENABLE ROW LEVEL SECURITY;
 
+-- Supprimer les policies existantes avant de les recréer
+DROP POLICY IF EXISTS "Active users can view groups" ON public.groups;
+DROP POLICY IF EXISTS "Admins can manage groups" ON public.groups;
+
 -- Tous les utilisateurs actifs peuvent voir les groupes
 CREATE POLICY "Active users can view groups" ON public.groups
   FOR SELECT
@@ -252,6 +256,11 @@ CREATE POLICY "Admins can manage groups" ON public.groups
 
 -- RLS pour la table user_groups
 ALTER TABLE public.user_groups ENABLE ROW LEVEL SECURITY;
+
+-- Supprimer les policies existantes avant de les recréer
+DROP POLICY IF EXISTS "Users can view own groups" ON public.user_groups;
+DROP POLICY IF EXISTS "Admins can view all user groups" ON public.user_groups;
+DROP POLICY IF EXISTS "Admins can manage user groups" ON public.user_groups;
 
 -- Les utilisateurs peuvent voir leurs propres groupes
 CREATE POLICY "Users can view own groups" ON public.user_groups
@@ -273,6 +282,12 @@ CREATE POLICY "Admins can manage user groups" ON public.user_groups
 
 -- Activer RLS sur la table members
 ALTER TABLE public.members ENABLE ROW LEVEL SECURITY;
+
+-- Supprimer les policies existantes avant de les recréer
+DROP POLICY IF EXISTS "Active users can view own profile" ON public.members;
+DROP POLICY IF EXISTS "Active admins can view all members" ON public.members;
+DROP POLICY IF EXISTS "Active admins can update members" ON public.members;
+DROP POLICY IF EXISTS "Active users can update own profile" ON public.members;
 
 -- Nouvelle politique : Les utilisateurs actifs peuvent voir leur propre profil
 CREATE POLICY "Active users can view own profile" ON public.members

--- a/supabase/migrations/20250820140000_add_rls_policies.sql
+++ b/supabase/migrations/20250820140000_add_rls_policies.sql
@@ -66,6 +66,12 @@ $$ LANGUAGE plpgsql SECURITY DEFINER STABLE;
 
 -- ====== POLICIES SIMPLES POUR LA TABLE MEMBERS ======
 
+-- Supprimer les policies existantes avant de les recréer
+DROP POLICY IF EXISTS "Users can insert own member" ON public.members;
+DROP POLICY IF EXISTS "Anyone can view members" ON public.members;
+DROP POLICY IF EXISTS "Users can update own member" ON public.members;
+DROP POLICY IF EXISTS "Admins can do everything on members" ON public.members;
+
 -- Permettre aux utilisateurs de créer leur propre entrée member
 CREATE POLICY "Users can insert own member" 
 ON public.members
@@ -98,6 +104,11 @@ WITH CHECK (is_admin());
 
 -- ====== POLICIES SIMPLES POUR LA TABLE USER_GROUPS ======
 
+-- Supprimer les policies existantes avant de les recréer
+DROP POLICY IF EXISTS "Users can insert into user_groups" ON public.user_groups;
+DROP POLICY IF EXISTS "Users can view own groups" ON public.user_groups;
+DROP POLICY IF EXISTS "Admins can do everything on user_groups" ON public.user_groups;
+
 -- Permettre l'insertion dans user_groups pour son propre user_id
 -- Note: La vérification du groupe public se fait dans la logique métier
 CREATE POLICY "Users can insert into user_groups" 
@@ -122,6 +133,10 @@ USING (is_admin())
 WITH CHECK (is_admin());
 
 -- ====== POLICIES SIMPLES POUR LA TABLE GROUPS ======
+
+-- Supprimer les policies existantes avant de les recréer
+DROP POLICY IF EXISTS "Anyone can view groups" ON public.groups;
+DROP POLICY IF EXISTS "Admins can do everything on groups" ON public.groups;
 
 -- Tout le monde peut voir les groupes
 CREATE POLICY "Anyone can view groups" 

--- a/supabase/migrations/20250822090000_add_slack_integration.sql
+++ b/supabase/migrations/20250822090000_add_slack_integration.sql
@@ -61,6 +61,12 @@ CREATE INDEX IF NOT EXISTS idx_slack_activity_log_created_at ON slack_activity_l
 -- Policies pour slack_app_config (admin seulement)
 ALTER TABLE slack_app_config ENABLE ROW LEVEL SECURITY;
 
+-- Supprimer les policies existantes avant de les recréer
+DROP POLICY IF EXISTS "Admin can view Slack app config" ON slack_app_config;
+DROP POLICY IF EXISTS "Admin can insert Slack app config" ON slack_app_config;
+DROP POLICY IF EXISTS "Admin can update Slack app config" ON slack_app_config;
+DROP POLICY IF EXISTS "Admin can delete Slack app config" ON slack_app_config;
+
 -- Admin peut voir la config
 CREATE POLICY "Admin can view Slack app config" ON slack_app_config
   FOR SELECT 
@@ -114,6 +120,13 @@ CREATE POLICY "Admin can delete Slack app config" ON slack_app_config
 
 -- Policies pour slack_activity_log
 ALTER TABLE slack_activity_log ENABLE ROW LEVEL SECURITY;
+
+-- Supprimer les policies existantes avant de les recréer
+DROP POLICY IF EXISTS "Admin can view all Slack logs" ON slack_activity_log;
+DROP POLICY IF EXISTS "Users can view own Slack logs" ON slack_activity_log;
+DROP POLICY IF EXISTS "Users can insert own Slack logs" ON slack_activity_log;
+DROP POLICY IF EXISTS "No one can update Slack logs" ON slack_activity_log;
+DROP POLICY IF EXISTS "Admin can delete Slack logs" ON slack_activity_log;
 
 -- Les admins peuvent voir tous les logs
 CREATE POLICY "Admin can view all Slack logs" ON slack_activity_log


### PR DESCRIPTION
- Ajout de DROP POLICY IF EXISTS avant TOUS les CREATE POLICY
- Corrigé dans: auth_refactor, add_rls_policies, add_slack_integration
- Les scripts du 23 août étaient déjà corrects
- Garantit que les migrations peuvent être exécutées plusieurs fois sans erreur

🤖 Generated with [Claude Code](https://claude.ai/code)