### PR TITLE
fix: handle archived Slack channels and add missing invite permissions

### DIFF
--- a/app/api/slack/auth/route.ts
+++ b/app/api/slack/auth/route.ts
@@ -14,8 +14,10 @@ export async function GET(request: NextRequest) {
     'channels:manage',      // Créer et gérer les canaux
     'channels:read',        // Lire les infos des canaux  
     'channels:history',     // Lire l'historique
+    'channels:write.invites', // Inviter des utilisateurs aux canaux publics
     'groups:read',          // Lire les canaux privés
     'groups:write',         // Gérer les canaux privés
+    'groups:write.invites', // Inviter des utilisateurs aux canaux privés
     'groups:history',       // Historique canaux privés
     'users:read',           // Lire les infos utilisateurs
     'users:read.email',     // Lire les emails


### PR DESCRIPTION
- Add automatic channel unarchiving when trying to invite users
- Add missing scopes: channels:write.invites and groups:write.invites
- Handle is_archived error with retry after unarchiving
- Improve error handling and logging for channel operations

🤖 Generated with [Claude Code](https://claude.ai/code)