### PR TITLE
fix: fix environment banner not showing in dev

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -39,7 +39,7 @@ export default async function AdminPage() {
       {/* Navigation */}
       <AdminNav websiteUrl={websiteUrl} highlightUrl={highlightUrl} />
       
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-8 pb-8">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-8">
         {/* Statistics Overview */}
         <StatsOverview />
         

--- a/components/EnvironmentBanner.tsx
+++ b/components/EnvironmentBanner.tsx
@@ -1,18 +1,11 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-
 export default function EnvironmentBanner() {
-  const [env, setEnv] = useState<string>('')
-
-  useEffect(() => {
-    // Récupérer l'environnement depuis la variable d'environnement
-    const environment = process.env.NEXT_PUBLIC_ENV || 'development'
-    setEnv(environment)
-  }, [])
+  // Récupérer l'environnement directement (disponible au build time)
+  const env = process.env.NEXT_PUBLIC_ENV || 'development'
 
   // Ne pas afficher le bandeau en production
-  if (!env || env === 'production') {
+  if (env === 'production') {
     return null
   }
 


### PR DESCRIPTION
- Remove useState and useEffect, use process.env directly
- Process.env variables are resolved at build time, not runtime
- Keep conditional padding-top for dev/test environments only
- Increase admin page top padding to prevent navigation overlap

🤖 Generated with [Claude Code](https://claude.ai/code)